### PR TITLE
Add specs and README for includes matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,26 +85,28 @@ $jsonResponseSubject->equal($expectedJson, ['including' => ['id']]);
 Also you can specify json path on which matching should be done via `at` options. We will back to this later since all matchers supports this option.
 
 ### includes
-This matcher is pretty match the same as `equal` matcher except that is recursively scan given JSON and tries to find expected JSON in any values. This is useful for cases when you checking that some record exists in collection and you do not know or don't want to know specific path to it.
+This matcher is pretty match the same as `equal` matcher except that is recursively scan given JSON and tries to find any inclusions of given JSON. This is useful for cases when you checking that some record exists in collection and you do not know or don't want to know specific path to it.
 
 ```php
 $json = <<<JSON
 {
+    "id": 1,
+    "name": "Foo",
     "collection": [
-        "json",
-        "matcher"
+        {"id": 1, "name": "Foo"},
+        {"id": 2, "name": "Bar"},
     ]
 }
 JSON;
 
-$needle = '"matcher"';
 $matcher
     ->setSubject($json)
-    ->includes($needle, ['at' => 'collection'])
+    ->includes('{"name": "Bar"}') // check for subset inclusion
+    ->includes('"Foo"', ['at' => 'collection']) // check for value inclusion
 ;
 ```
 
-This matcher works the same way as `equal` matcher, so it accepts same options.
+Since this matcher works the same way as `equal` matcher, it accepts same options.
 
 ### hasPath
 This matcher checks if given JSON have specific path ot not.

--- a/spec/JsonMatcherSpec.php
+++ b/spec/JsonMatcherSpec.php
@@ -343,6 +343,24 @@ class JsonMatcherSpec extends ObjectBehavior
         $json = '[{"id":1,"two":3}]';
         $this->setSubject(($json))->shouldNotThrow()->duringIncludes('{"two":3}');
     }
+
+    function it_matches_an_subset_included_in_a_hash()
+    {
+        $json = '{"id": 1, "name": "Foo"}';
+        $this->setSubject($json)->shouldNotThrow()->duringIncludes('{"name":"Foo"}');
+    }
+
+    function it_matches_an_subset_included_in_a_collection_of_hashes()
+    {
+        $json = '[{"id": 1, "name": "Foo"}, {"id": 2, "name": "Bar"}]';
+        $this->setSubject($json)->shouldNotThrow()->duringIncludes('{"name":"Bar"}');
+    }
+
+    function it_should_throw_exception_if_it_cant_find_subset_in_hash()
+    {
+        $json = '{"id": 1, "name": "Foo"}';
+        $this->setSubject($json)->shouldThrow()->duringIncludes('{"name":"Bar"}');
+    }
     // </editor-fold>
 
 }


### PR DESCRIPTION
`includes` matcher already implements #10, so no need to add more matcher options.

Added example in README section and test cases for searching JSON subset inclusion.
