### PR TITLE
Schema matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,60 @@ $matcher
 ;
 ```
 
+### matchesSchema
+
+`hasPath` and `hasType` matchers provide you a simple way to verify JSON structure. But if you want to verify large part of JSON or event hole structure with this matchers, it can be quite tedious. What can be used instead is [Json Schema](http://json-schema.org/) and this matcher allows you to verify JSON or it part on schema matching.
+
+```php
+$schema = <<<JSONSCHEMA
+{
+	"title": "User json representation",
+	"type": "object",
+	"properties": {
+		"firstName": {
+			"type": "string"
+		},
+		"last_name": {
+			"type": "string"
+		},
+		"created_at": {
+			"description": "Date in ISO-8601 format",
+			"type": "string"
+		}
+	},
+	"required": ["first_name", "last_name"]
+}
+JSONSCHEMA;
+
+$json = <<<JSON
+{
+    "first_name": "Alice",
+    "last_name": "Miller",
+    "created_at": "2015-09-02T00:00:00+00:00"
+}
+JSON;
+
+$matcher
+  ->setSubject($json)
+  ->matchesSchema($schema);
+```
+
+Json schema is quite verbose, and you probably want to store it in separate files. Also you can use things like [RAML](http://raml.org/) or [api-blueprint](https://apiblueprint.org/) to generate schemas for responses in your functional tests from API documentation. But currently `JsonMatcher` doesn't provide you an API to load files since you can do that via very different ways. What is suggested is to create separate function to load schema file and return it's contents:
+
+```
+function fromFile($fileName) {
+    return file_get_contents(sprintf('file://%s/%s', __DIR__ . '/../support/schema', $fileName));
+}
+
+$matcher
+  ->matchesSchema(fromFile('users_schema.json'));
+```
+
+Supported options:
+
+ - `at` - verify JSON Schema by given path.
+ - `excluding` - exclude specific keys before matching. Please not that excluded-by-default are ignored here.
+
 ### Negative matching
 To invert expectations just call matcher methods with `not` prefix:
 ```php

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ composer require fesor/json_matcher
 
 Then you will need an `JsonMatcher` instance to be created. To do this, you can:
 
- - manually create instance with all dependencies and set subject
  - use named constructor `JsonMatcher::create` as static factory-method. It will handle all dependencies for you.
  - use JsonMatcherFactory. This is useful when you have some IoC container in your test framework (Behat for example). In this case you'll need to register this class as a service.
+ - manually create instance with all dependencies and set subject
 
 Subject on which assertion will be preformed is setted up in matcher consturctor. If you want to reuse the same instance of matcher for every assertions, you can just change subject via `setSubject` method.
 
@@ -257,7 +257,6 @@ $matcher
 Supported options:
 
  - `at` - verify JSON Schema by given path.
- - `excluding` - exclude specific keys before matching. Please not that excluded-by-default are ignored here.
 
 ### Negative matching
 To invert expectations just call matcher methods with `not` prefix:

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
       "psr-4": {"Fesor\\JsonMatcher\\": "src/", "spec\\Fesor\\JsonMatcher\\": "spec/"}
     },
     "require": {
-      "php": ">=5.4.0"
+      "php": ">=5.4.0",
+        "justinrainbow/json-schema": "~1.3"
     },
     "require-dev": {
-      "phpspec/phpspec": "2.1.*@dev",
+      "phpspec/phpspec": "2.2.*@dev",
       "fabpot/php-cs-fixer": "~0.5",
       "henrikbjorn/phpspec-code-coverage": "~1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,75 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0bd7d8e797e593c27679677537904e72",
-    "packages": [],
+    "hash": "381a5cbba6a7782a7d3ef6ad3409561a",
+    "packages": [
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "1.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce",
+                "reference": "8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "json-schema/json-schema-test-suite": "1.1.0",
+                "phpdocumentor/phpdocumentor": "~2",
+                "phpunit/phpunit": "~3.7"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JsonSchema": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2015-07-14 16:29:50"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -243,7 +310,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/74bfbbace9775ec065a9431da862862b237dd404",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/6c5809238d07e3ef6c60cd4d0493900e67573cb4",
                 "reference": "74bfbbace9775ec065a9431da862862b237dd404",
                 "shasum": ""
             },

--- a/spec/Helper/JsonHelperSpec.php
+++ b/spec/Helper/JsonHelperSpec.php
@@ -2,11 +2,22 @@
 
 namespace spec\Fesor\JsonMatcher\Helper;
 
+use Fesor\JsonMatcher\Exception\JsonNotMatchesSchemaException;
 use Fesor\JsonMatcher\Exception\MissingPathException;
+use JsonSchema\Validator;
 use PhpSpec\ObjectBehavior;
 
 class JsonHelperSpec extends ObjectBehavior
 {
+
+    private $validator;
+
+    function let(Validator $jsonSchemaValidator)
+    {
+        $this->validator = $jsonSchemaValidator;
+
+        $this->beConstructedWith($jsonSchemaValidator);
+    }
 
     function it_parses_json()
     {
@@ -183,6 +194,19 @@ JSON;
         $this->isIncludes($obj, '"find"')->shouldBe(true);
         $this->isIncludes($obj, '"find me"')->shouldBe(true);
         $this->isIncludes($obj, '"not find me"')->shouldBe(false);
+    }
+
+    function it_validates_json_schema()
+    {
+        $errors = [[
+            'property' => 'prop',
+            'message' => 'message'
+        ]];
+        $this->validator->check('json', 'schema')->willReturn($errors);
+        $this->validator->getErrors()->willReturn($errors);
+        $this->validator->reset()->shouldBeCalled();
+
+        $this->validateJsonSchema('json', 'schema');
     }
 
 }

--- a/src/Exception/JsonNotMatchesSchemaException.php
+++ b/src/Exception/JsonNotMatchesSchemaException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fesor\JsonMatcher\Exception;
+
+class JsonNotMatchesSchemaException  extends MatchException
+{
+    public static function create($errors, array $options) {
+
+        if (self::isPositive($options)) {
+            $message = sprintf("Json doesn't matches schema%s:\n %s", self::getAt($options), self::processErrors($errors));
+        } else {
+            $message = sprintf('Expected that json%s doesn\'t matches schema', self::getAt($options));
+        }
+
+        return new static($message);
+    }
+
+    private static function processErrors(array $errors)
+    {
+        return implode("\n", array_map(function (array $error) {
+
+            return sprintf(' - %s: %s', $error['property'], $error['message']);
+        }, $errors));
+    }
+}

--- a/src/Helper/JsonHelper.php
+++ b/src/Helper/JsonHelper.php
@@ -3,6 +3,7 @@
 namespace Fesor\JsonMatcher\Helper;
 
 use Fesor\JsonMatcher\Exception\MissingPathException;
+use JsonSchema\Validator;
 
 /**
  * Class JsonHelper
@@ -12,6 +13,13 @@ use Fesor\JsonMatcher\Exception\MissingPathException;
  */
 class JsonHelper
 {
+
+    private $schemaValidator;
+
+    public function __construct(Validator $schemaValidator)
+    {
+        $this->schemaValidator = $schemaValidator;
+    }
 
     /**
      * Returns parsed JSON data or its part by given path
@@ -200,5 +208,14 @@ class JsonHelper
         }
 
         return $json;
+    }
+
+    public function validateJsonSchema($json, $schema)
+    {
+        $this->schemaValidator->check($json, $schema);
+        $errors = $this->schemaValidator->getErrors();
+        $this->schemaValidator->reset();
+
+        return $errors;
     }
 }

--- a/src/Helper/JsonHelper.php
+++ b/src/Helper/JsonHelper.php
@@ -3,7 +3,6 @@
 namespace Fesor\JsonMatcher\Helper;
 
 use Fesor\JsonMatcher\Exception\MissingPathException;
-use Seld\JsonLint\JsonParser;
 
 /**
  * Class JsonHelper


### PR DESCRIPTION
Adds json schema matcher.

### Breaking changes

- `JsonHelper` now requires `JsonSchema\Validator` instance to be passed in

Checklist:

- [ ] Implement `validateSchema` matcher
- [ ] Implement `matchesSchema`
- [ ] Update README.md

